### PR TITLE
Support for multiple cut areas

### DIFF
--- a/rslidar_pointcloud/src/rawdata.cc
+++ b/rslidar_pointcloud/src/rawdata.cc
@@ -19,7 +19,11 @@
  */
 #include "rawdata.h"
 
+#include <xmlrpcpp/XmlRpcValue.h>
+
 #include <limits>
+#include <stdexcept>
+#include <string>
 
 namespace rslidar_rawdata
 {
@@ -88,19 +92,57 @@ void RawData::loadConfigFile(ros::NodeHandle node, ros::NodeHandle private_nh)
 
   ROS_INFO_STREAM("[cloud][rawdata] initialize resolution type: " << (dis_resolution_mode_?"1 cm":"0.5 cm") << ", intensity mode: " << intensity_mode_);
 
-  private_nh.param<float>("start_clip_angle_deg", start_clip_angle_, 0.F);
-  private_nh.param<float>("end_clip_angle_deg", end_clip_angle_, 360.F);
+  XmlRpc::XmlRpcValue cut_pairs;
+  if (private_nh.getParam("cut_angles", cut_pairs))
+  {
+    if (cut_pairs.getType() != XmlRpc::XmlRpcValue::TypeArray)
+    {
+      const std::string fatal = "Parameter 'cut_angles' has to be of type array";
+      ROS_FATAL_STREAM(fatal);
+      throw std::invalid_argument(fatal);
+     }
 
-  assert(std::abs(start_clip_angle_) <= 360.F);
-  assert(std::abs(end_clip_angle_) <= 360.F);
+    for (size_t i = 0; i < cut_pairs.size(); ++i)
+    {
+       if (cut_pairs[i].getType() != XmlRpc::XmlRpcValue::TypeArray)
+       {
+         const std::string fatal = "Parameter 'cut_angles' has to be an array of arrays. Element with index "
+             + std::to_string(i) + " is not an array";
+         ROS_FATAL_STREAM(fatal);
+         throw std::invalid_argument(fatal);
+       }
 
-  start_clip_angle_ = std::fmod(start_clip_angle_ + 360.F, 360.F);
-  end_clip_angle_ = std::fmod(end_clip_angle_ + 360.F, 360.F);
+      if (cut_pairs[i].size() != 2)
+      {
+        const std::string fatal = "Parameter 'cut_angles' has to be an array of pairs. Element with index "
+            + std::to_string(i) + " is not a pair (size != 2)";
+        ROS_FATAL_STREAM(fatal);
+        throw std::invalid_argument(fatal);
+      }
 
-  ROS_INFO("Clipping horizontal angle to range [%f, %f] degree", start_clip_angle_, end_clip_angle_);
+      if (cut_pairs[i][0].getType() != XmlRpc::XmlRpcValue::TypeDouble
+            || cut_pairs[i][1].getType() != XmlRpc::XmlRpcValue::TypeDouble)
+      {
+        const std::string fatal = "Parameter 'cut_angles' has to be an array of double pairs. Pair with index "
+            + std::to_string(i) + " has non-double value";
+        ROS_FATAL_STREAM(fatal);
+        throw std::invalid_argument(fatal);
+      }
 
-  start_clip_angle_ = static_cast<float>(start_clip_angle_ * M_PI / 180.);
-  end_clip_angle_ = static_cast<float>(end_clip_angle_ * M_PI / 180.);
+      double start_cut_angle = cut_pairs[i][0];
+      double end_cut_angle = cut_pairs[i][1];
+
+      start_cut_angle = std::fmod(start_cut_angle + 360.0, 360.0);
+      end_cut_angle = std::fmod(end_cut_angle + 360.0, 360.0);
+
+      ROS_INFO("Cut between horizontal angle range [%f, %f] degrees", start_cut_angle, end_cut_angle);
+
+      start_cut_angle = start_cut_angle * M_PI / 180.0;
+      end_cut_angle = end_cut_angle * M_PI / 180.0;
+
+      cut_angles_.emplace_back(static_cast<float>(start_cut_angle), static_cast<float>(end_cut_angle));
+    }
+  }
 
   if (model == "RS16")
   {
@@ -861,19 +903,9 @@ void RawData::unpack(const rslidar_msgs::rslidarPacket& pkt, pcl::PointCloud<pcl
         float arg_horiz = (float)azimuth_corrected / 18000.0f * M_PI;
         float arg_horiz_orginal = arg_horiz;
 
-        if (start_clip_angle_< end_clip_angle_)
+        if (skipAngle(arg_horiz_orginal))
         {
-          if (arg_horiz < start_clip_angle_ || arg_horiz > end_clip_angle_)
-          {
-            continue;
-          }
-        }
-        else
-        {
-          if (arg_horiz < start_clip_angle_ && arg_horiz > end_clip_angle_)
-          {
-            continue;
-          }
+          continue;
         }
 
         union two_bytes tmp;
@@ -1026,19 +1058,9 @@ void RawData::unpack_RS32(const rslidar_msgs::rslidarPacket& pkt, pcl::PointClou
         float arg_horiz_orginal = (float)azimuth_corrected_f / 18000.0f * M_PI;
         float arg_horiz = (float)azimuth_corrected / 18000.0f * M_PI;
 
-        if (start_clip_angle_< end_clip_angle_)
+        if (skipAngle(arg_horiz))
         {
-          if (arg_horiz < start_clip_angle_ || arg_horiz > end_clip_angle_)
-          {
-            continue;
-          }
-        }
-        else
-        {
-          if (arg_horiz < start_clip_angle_ && arg_horiz > end_clip_angle_)
-          {
-            continue;
-          }
+          continue;
         }
 
         union two_bytes tmp;
@@ -1181,4 +1203,31 @@ void RawData::unpack_RS32(const rslidar_msgs::rslidarPacket& pkt, pcl::PointClou
   }
 }
 
+bool RawData::skipAngle(const float angle_horizontal)
+{
+  for (const auto& start_end_pair : cut_angles_)
+  {
+    const auto& start = start_end_pair.first;
+    const auto& end = start_end_pair.second;
+
+    if (start < end)
+    {
+      if (angle_horizontal >= start && angle_horizontal <= end)
+      {
+        return true;
+      }
+    }
+    else // passing the 360 deg mark, e.g. from 270 to 10 degree
+    {
+      if (angle_horizontal >= start || angle_horizontal <= end)
+      {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
 }  // namespace rs_pointcloud
+

--- a/rslidar_pointcloud/src/rawdata.h
+++ b/rslidar_pointcloud/src/rawdata.h
@@ -31,7 +31,11 @@
 #include <pcl_ros/point_cloud.h>
 #include <pcl_ros/impl/transforms.hpp>
 #include <pcl_conversions/pcl_conversions.h>
+
 #include <stdio.h>
+#include <utility>
+#include <vector>
+
 namespace rslidar_rawdata
 {
 // static const float  ROTATION_SOLUTION_ = 0.18f;  //水平角分辨率 10hz
@@ -167,6 +171,8 @@ public:
   int intensityFactor;
 
 private:
+  bool skipAngle(const float angle_horizontal);
+
   float R1_;
   float R2_;
   bool angle_flag_;
@@ -175,8 +181,7 @@ private:
   float max_distance_;
   float min_distance_;
   int dis_resolution_mode_;
-  float start_clip_angle_;
-  float end_clip_angle_;
+  std::vector<std::pair<float, float>> cut_angles_;
   int return_mode_;
   bool info_print_flag_;
 };


### PR DESCRIPTION
Allows specifying multiple cut areas to exclude multiple areas in the field of view.

Usage:
Specify multiple pairs via a parameters:

```xml
cut_angles: [[start_1, stop_1], [start_2, stop_2]]
```